### PR TITLE
ninja: increase maximum suffix length

### DIFF
--- a/core/ninja.mk
+++ b/core/ninja.mk
@@ -96,7 +96,7 @@ KATI_NINJA_SUFFIX := $(KATI_NINJA_SUFFIX)-mmma-$(call replace_space_and_slash,$(
 endif
 
 my_checksum_suffix :=
-my_ninja_suffix_too_long := $(filter 1, $(shell v='$(KATI_NINJA_SUFFIX)' && echo $$(($${$(pound)v} > 64))))
+my_ninja_suffix_too_long := $(filter 1, $(shell v='$(KATI_NINJA_SUFFIX)' && echo $$(($${$(pound)v} > 240))))
 ifneq ($(my_ninja_suffix_too_long),)
 # Replace the suffix with a checksum if it gets too long.
 my_checksum_suffix := $(KATI_NINJA_SUFFIX)


### PR DESCRIPTION
HFS+ and ext4 both support filenames up to 255 characters in length.
It should be ok to allow longer suffixes. This fixes mmp in places with
long paths (where otherwise the build system defaults to using md5sum
for the suffix)

Change-Id: I93e39875470417ce1b0febe7a9e0da37b56b5b00
