### PR TITLE
Revert "qcom: Select Sony display/media variants for Sony devices"

### DIFF
--- a/core/qcom_target.mk
+++ b/core/qcom_target.mk
@@ -91,14 +91,8 @@ $(call project-set-path,wlan,hardware/qcom/wlan)
 $(call project-set-path,bt-vendor,hardware/qcom/bt)
 else
 $(call project-set-path,qcom-audio,hardware/qcom/audio-caf/$(QCOM_HARDWARE_VARIANT))
-
-ifeq ($(SONY_BF64_KERNEL_VARIANT),true)
-$(call project-set-path,qcom-display,hardware/qcom/display-caf/sony)
-$(call project-set-path,qcom-media,hardware/qcom/media-caf/sony)
-else
 $(call project-set-path,qcom-display,hardware/qcom/display-caf/$(QCOM_HARDWARE_VARIANT))
 $(call project-set-path,qcom-media,hardware/qcom/media-caf/$(QCOM_HARDWARE_VARIANT))
-endif
 
 $(call set-device-specific-path,CAMERA,camera,hardware/qcom/camera)
 $(call set-device-specific-path,GPS,gps,hardware/qcom/gps)


### PR DESCRIPTION
1. The Sony kernel is no longer BF64-based.
2. There is no reason for Sony devices to set
   the BOARD_USES_QCOM_HARDWARE flag, since they
   are meant to be using AOSP code + select patches.

Revert for now until a better solution is decided upon.

This reverts commit be202afa17314f84ce69ee33a6936ca9abbf499b.

Change-Id: I94749d116340e9eb4a2fcc88a2b4514719e2279d