### PR TITLE
build: repopick: Avoid failing on commits lookup

### DIFF
--- a/tools/repopick.py
+++ b/tools/repopick.py
@@ -328,6 +328,8 @@ if __name__ == '__main__':
         # Check if change is already picked to HEAD...HEAD~check_picked_count
         found_change = False
         for i in range(0, check_picked_count):
+            if subprocess.call(['git', 'cat-file', '-e', 'HEAD~{0}'.format(i)], cwd=project_path, stderr=open(os.devnull, 'wb')):
+                continue
             output = subprocess.check_output(['git', 'show', '-q', 'HEAD~{0}'.format(i)], cwd=project_path).split()
             if 'Change-Id:' in output:
                 head_change_id = ''


### PR DESCRIPTION
 * Some projects with multiple merges and
    discountinuous histories could trigger
    an error here when the HEAD~{?} does
    not exist, hence avoid this by ignoring
    the commit and continue the search

Change-Id: Ice28c87d1bf8897da52236b637bbb0c5d349f848